### PR TITLE
Closes #17

### DIFF
--- a/evm/contracts/SwapPoolAmplified.sol
+++ b/evm/contracts/SwapPoolAmplified.sol
@@ -97,10 +97,11 @@ contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon, ReentrancyGuard {
         require(msg.sender == FACTORY && _tokenIndexing[0] == address(0));  // dev: swap curves may only be initialized once by the factory
         // Check that the amplification is correct.
         require(amp < FixedPointMathLib.WAD);  // dev: amplification not set correctly.
-        // Check for a misunderstanding regarding how many assets this pool supports.
-        require(assets.length > 0 && assets.length <= MAX_ASSETS);  // dev: invalid asset count
-        // Check if an invalid weight count has been provided
-        require(weights.length == assets.length); //dev: invalid weight count
+        // Note there is no need to check whether assets.length/weights.length are valid, as invalid arguments
+        // will either cause the function to fail (e.g. if assets.length > MAX_ASSETS the assignment
+        // to initialBalances[it] will fail) or will cause the pool to get initialized with an undesired state
+        // (and the pool shouldn't be used by anyone until its configuration has been finalised). 
+        // In any case, the factory does check for valid assets/weights arguments to prevent erroneous configurations. 
         
         unchecked {
             _oneMinusAmp = int256(FixedPointMathLib.WAD - amp);

--- a/evm/contracts/SwapPoolFactory.sol
+++ b/evm/contracts/SwapPoolFactory.sol
@@ -61,6 +61,13 @@ contract CatalystSwapPoolFactory is Ownable, ICatalystV1FactoryEvents {
         string memory symbol,
         address chainInterface
     ) external returns (address) {
+        // Check if an invalid asset count has been provided
+        require(assets.length > 0);  // dev: invalid asset count
+        // Check if an invalid weight count has been provided
+        require(weights.length == assets.length); //dev: invalid weight count
+        // init_balances length not checked: if shorter than assets, the funds transfer loop
+        // will fail. If longer, values will just be ignored.
+
         // Create a minimal transparent proxy:
         address swapPool = Clones.clone(poolTemplate);
 

--- a/evm/contracts/SwapPoolVolatile.sol
+++ b/evm/contracts/SwapPoolVolatile.sol
@@ -87,11 +87,12 @@ contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon, ReentrancyGuard {
         require(msg.sender == FACTORY && _tokenIndexing[0] == address(0));  // dev: swap curves may only be initialized once by the factory
         // Check that the amplification is correct.
         require(amp == FixedPointMathLib.WAD);  // dev: amplification not set correctly.
-        // Check for a misunderstanding regarding how many assets this pool supports.
-        require(assets.length > 0 && assets.length <= MAX_ASSETS);  // dev: invalid asset count
-        // Check if an invalid weight count has been provided
-        require(weights.length == assets.length); //dev: invalid weight count
-        
+        // Note there is no need to check whether assets.length/weights.length are valid, as invalid arguments
+        // will either cause the function to fail (e.g. if assets.length > MAX_ASSETS the assignment
+        // to initialBalances[it] will fail) or will cause the pool to get initialized with an undesired state
+        // (and the pool shouldn't be used by anyone until its configuration has been finalised). 
+        // In any case, the factory does check for valid assets/weights arguments to prevent erroneous configurations. 
+
         // Compute the security limit.
         uint256[] memory initialBalances = new uint256[](MAX_ASSETS);
         uint256 maxUnitCapacity = 0;


### PR DESCRIPTION
On pool deployment, the `assets` and `weights` arguments length are now checked on the factory. An explanatory comment has been added to the `initializeSwapCurves()` functions. Note that the `assets.length <= MAX_ASSETS` check has been completely removed. However, for that case, `initializeSwapCurves()` will fail (assignment to `initialBalances[it]` will fail). This has also been commented on the `initializeSwapCurves()` functions.