### PR TITLE
Closes #36

### DIFF
--- a/evm/contracts/SwapPoolAmplified.sol
+++ b/evm/contracts/SwapPoolAmplified.sol
@@ -39,7 +39,7 @@ import "./ICatalystV1Pool.sol";
  * over the pool. 
  * !If finishSetup is not called, the pool can be drained!
  */
-contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon, ReentrancyGuard {
+contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon {
     using SafeTransferLib for ERC20;
 
     //--- ERRORS ---//
@@ -1182,7 +1182,7 @@ contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 U,
         uint256 minOut,
         bytes32 swapHash
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
         // Only allow connected pools
         if (!_poolConnection[channelId][fromPool]) revert PoolNotConnected(channelId, fromPool);
         // The chainInterface is the only valid caller of this function.
@@ -1279,7 +1279,7 @@ contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 minOut,
         address fallbackUser,
         bytes memory calldata_
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
 
         // Only allow connected pools
         if (!_poolConnection[channelId][toPool]) revert PoolNotConnected(channelId, toPool);
@@ -1445,7 +1445,7 @@ contract CatalystSwapPoolAmplified is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 U,
         uint256 minOut,
         bytes32 swapHash
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
         // The chainInterface is the only valid caller of this function.
         require(msg.sender == _chainInterface);
         // Only allow connected pools

--- a/evm/contracts/SwapPoolCommon.sol
+++ b/evm/contracts/SwapPoolCommon.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.16;
 
 import {ERC20} from 'solmate/src/tokens/ERC20.sol';
 import {SafeTransferLib} from 'solmate/src/utils/SafeTransferLib.sol';
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/Multicall.sol";
 import "./SwapPoolFactory.sol";
@@ -27,6 +28,7 @@ import "./interfaces/ICatalystV1PoolErrors.sol";
 abstract contract CatalystSwapPoolCommon is
     Initializable,
     Multicall,
+    ReentrancyGuard,
     ERC20,
     ICatalystV1Pool
 {
@@ -392,7 +394,7 @@ abstract contract CatalystSwapPoolCommon is
         uint256 escrowAmount,
         address escrowToken,
         uint32 blockNumberMod
-    ) public override virtual {
+    ) nonReentrant public override virtual {
         require(msg.sender == _chainInterface);  // dev: Only _chainInterface
 
         bytes32 sendAssetHash = _computeSendAssetHash(
@@ -423,7 +425,7 @@ abstract contract CatalystSwapPoolCommon is
         uint256 escrowAmount,
         address escrowToken,
         uint32 blockNumberMod
-    ) public override virtual {
+    ) nonReentrant public override virtual {
         require(msg.sender == _chainInterface);  // dev: Only _chainInterface
 
         bytes32 sendAssetHash = _computeSendAssetHash(
@@ -454,7 +456,7 @@ abstract contract CatalystSwapPoolCommon is
         uint256 U,
         uint256 escrowAmount,
         uint32 blockNumberMod
-    ) public override virtual {
+    ) nonReentrant public override virtual {
         require(msg.sender == _chainInterface);  // dev: Only _chainInterface
 
         bytes32 sendLiquidityHash = _computeSendLiquidityHash(
@@ -482,7 +484,7 @@ abstract contract CatalystSwapPoolCommon is
         uint256 U,
         uint256 escrowAmount,
         uint32 blockNumberMod
-    ) public override virtual {
+    ) nonReentrant public override virtual {
         require(msg.sender == _chainInterface);  // dev: Only _chainInterface
 
         bytes32 sendLiquidityHash = _computeSendLiquidityHash(

--- a/evm/contracts/SwapPoolVolatile.sol
+++ b/evm/contracts/SwapPoolVolatile.sol
@@ -39,7 +39,7 @@ import "./ICatalystV1Pool.sol";
  * over the pool. 
  * !If finishSetup is not called, the pool can be drained!
  */
-contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon, ReentrancyGuard {
+contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon {
     using SafeTransferLib for ERC20;
 
     //--- ERRORS ---//
@@ -804,7 +804,7 @@ contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 U,
         uint256 minOut,
         bytes32 swapHash
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
         // Only allow connected pools
         if (!_poolConnection[channelId][fromPool]) revert PoolNotConnected(channelId, fromPool);
         // The chainInterface is the only valid caller of this function.
@@ -896,7 +896,7 @@ contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 minOut,
         address fallbackUser,
         bytes memory calldata_
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
         // Only allow connected pools
         if (!_poolConnection[channelId][toPool]) revert PoolNotConnected(channelId, toPool);
 
@@ -1014,7 +1014,7 @@ contract CatalystSwapPoolVolatile is CatalystSwapPoolCommon, ReentrancyGuard {
         uint256 U,
         uint256 minOut,
         bytes32 swapHash
-    ) public override returns (uint256) {
+    ) nonReentrant public override returns (uint256) {
         // The chainInterface is the only valid caller of this function.
         require(msg.sender == _chainInterface);
         // Only allow connected pools


### PR DESCRIPTION
`nonReentrant` guards have been added to all functions that change ERC20 token balances, those are:
- `receiveAsset`
- `sendLiquidity`
- `receiveLiquidity`
- `sendAssetAck/Timeout`
- `sendLiquidityAck/Timeout`