### PR TITLE
Tell the destination application if a swap was underwritten

### DIFF
--- a/evm/script/config/config_contracts.json
+++ b/evm/script/config/config_contracts.json
@@ -1,10 +1,10 @@
 {
   "contracts": {
-    "amplified_mathlib": "0x1c66C42b71480CB826eF23094ae7F12edD59f4f5",
-    "amplified_template": "0xD8B97cd47EEE69Ef5554aFBDA8F7EDe4D9fd7d8d",
+    "amplified_mathlib": "0xc090dcdC90178c86CFB643f6ce64aBecD3360247",
+    "amplified_template": "0x65E17EB8Eb46a7FA97d9E5316893C95D5e84bf35",
     "factory": "0x343A85b1e0383A50D65adB5ed88B06cCF4187606",
-    "volatile_mathlib": "0xd29Ff5661e446f53c69241a5F697771905b643D4",
-    "volatile_template": "0x11A13784007510006c83978D1d0C82385df3A663"
+    "volatile_mathlib": "0x33D494F7AC4E506D31F37e3fD75CaE3ca87A3916",
+    "volatile_template": "0x35D30159b7A9B9098C1048cbe29168EffE7d3D02"
   },
   "registry": {
     "describer": "0x5514d9b55CdCbA70A6aF19Ca1E3443b1abEa104A",

--- a/evm/src/CatalystChainInterface.sol
+++ b/evm/src/CatalystChainInterface.sol
@@ -545,7 +545,7 @@ contract CatalystChainInterface is ICatalystChainInterface, Ownable, Bytes65 {
                 // The logic is not contained within a try - except so if the logic reverts
                 // the transaction will timeout and the user gets the input tokens on the sending chain.
                 // If this is not desired, wrap further logic in a try - except at dataTarget.
-                ICatalystReceiver(dataTarget).onCatalystCall(purchasedTokens, dataArguments);
+                ICatalystReceiver(dataTarget).onCatalystCall(purchasedTokens, dataArguments, false);
                 // If dataTarget doesn't implement onCatalystCall BUT implements a fallback function, the call will still succeed.
             }
             return 0x00;
@@ -579,7 +579,7 @@ contract CatalystChainInterface is ICatalystChainInterface, Ownable, Bytes65 {
                 // The logic is not contained within a try - except so if the logic reverts
                 // the transaction will timeout and the user gets the input tokens on the sending chain.
                 // If this is not desired, wrap further logic in a try - except at dataTarget.
-                ICatalystReceiver(dataTarget).onCatalystCall(purchasedVaultTokens, dataArguments);
+                ICatalystReceiver(dataTarget).onCatalystCall(purchasedVaultTokens, dataArguments, false);
                 // If dataTarget doesn't implement onCatalystCall BUT implements a fallback function, the call will still succeed.
             }
             return 0x00;
@@ -818,7 +818,7 @@ contract CatalystChainInterface is ICatalystChainInterface, Ownable, Bytes65 {
         if (calldataLength != 0) {
             address dataTarget = address(bytes20(cdata[2:2+20]));
             bytes calldata customCalldata = cdata[2+20:2+calldataLength];
-            ICatalystReceiver(dataTarget).onCatalystCall(purchasedTokens, customCalldata);
+            ICatalystReceiver(dataTarget).onCatalystCall(purchasedTokens, customCalldata, true);
         }
         
         emit SwapUnderwritten(

--- a/evm/src/interfaces/IOnCatalyst.sol
+++ b/evm/src/interfaces/IOnCatalyst.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.17;
 
 interface ICatalystReceiver {
-    /// @notice The callback from a catalyst call. To determine if the swap was an asset or liquidity swap, either the current balance should be checked or it should be encoded into data.
-    function onCatalystCall(uint256 purchasedTokens, bytes calldata data) external;
+    /** 
+     * @notice The callback from a catalyst call. To determine if the swap was an asset or liquidity swap, either the current balance should be checked or it should be encoded into data.
+     * @dev If you want full finality (not just economical finality)
+     * revert on underwritten == true.
+     */
+    function onCatalystCall(uint256 purchasedTokens, bytes calldata data, bool underwritten) external;
 }

--- a/evm/src/router/CatalystRouter.sol
+++ b/evm/src/router/CatalystRouter.sol
@@ -71,7 +71,7 @@ contract CatalystRouter is RouterImmutables, ICatalystRouter, Dispatcher, ICatal
         return command & Commands.FLAG_ALLOW_REVERT == 0;
     }
 
-    function onCatalystCall(uint256 /* purchasedTokens */, bytes calldata data) external {
+    function onCatalystCall(uint256 /* purchasedTokens */, bytes calldata data, bool /* underwritten */) external {
         bytes calldata commands = data.toBytes(0);
         bytes[] calldata inputs = data.toBytesArray(1);
 

--- a/evm/test/mocks/dummyTargetContract.sol
+++ b/evm/test/mocks/dummyTargetContract.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.19;
 import "./../../src/interfaces/IOnCatalyst.sol";
 
 contract DummyTargetContract is ICatalystReceiver {
-    event OnCatalystCallReceived(uint256 purchasedTokens, bytes data);
+    event OnCatalystCallReceived(uint256 purchasedTokens, bytes data, bool underwritten);
 
-    function onCatalystCall(uint256 purchasedTokens, bytes calldata data)
+    function onCatalystCall(uint256 purchasedTokens, bytes calldata data, bool underwritten)
         external
     {
-        emit OnCatalystCallReceived(purchasedTokens, data);
+        emit OnCatalystCallReceived(purchasedTokens, data, underwritten);
     }
 }

--- a/evm/test/underwriting/underwrite.t.sol
+++ b/evm/test/underwriting/underwrite.t.sol
@@ -96,8 +96,9 @@ contract TestUnderwrite is TestCommon, ICatalystReceiver {
     
     bytes on_catalyst_call_data;
 
-    function onCatalystCall(uint256 /* purchasedTokens */, bytes calldata data) external {
+    function onCatalystCall(uint256 /* purchasedTokens */, bytes calldata data, bool underwritten) external {
         on_catalyst_call_data = data;
+        assertEq(underwritten, true, "Underwrite not correctly indicated");
     }
 }
 


### PR DESCRIPTION
Tell the destination logic if the swap was underwritten. This can be used to disable underwriting by reverting if the value is true.

This is relevant for any application that wants to ensure that they ONLY receive trusted data.